### PR TITLE
Fix Bugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ program
   .parse(process.argv);
 
 // judge options
-const options = ['--patience'];
+const options = ['--patience', '--no-index'];
 if (program.cached) {
   options.push('--cached');
 }

--- a/index.js
+++ b/index.js
@@ -30,10 +30,14 @@ const output = fs.createWriteStream(`${realPath}/dest/diff.js`)
 output.write('var lineDiffExample="');
 
 // git diff
-const giff = spawn('git', ['diff']
-               .concat(options)
-               .concat(['--'])
-               .concat(program.args));
+const giff = spawn(
+  'git',
+  ['diff']
+    .concat(program.args)
+    .concat(['--'])
+    .concat(options)
+);
+
 giff.stdout.on('data', function (data) {
   // encode to JSON to get escaping
   const encoded = JSON.stringify(data.toString());

--- a/index.js
+++ b/index.js
@@ -33,9 +33,9 @@ output.write('var lineDiffExample="');
 const giff = spawn(
   'git',
   ['diff']
-    .concat(program.args)
-    .concat(['--'])
     .concat(options)
+    .concat(['--'])
+    .concat(program.args)
 );
 
 giff.stdout.on('data', function (data) {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ program
   .parse(process.argv);
 
 // judge options
-const options = ['--patience', '--no-index'];
+const options = ['--patience'];
 if (program.cached) {
   options.push('--cached');
 }

--- a/index.js
+++ b/index.js
@@ -30,7 +30,10 @@ const output = fs.createWriteStream(`${realPath}/dest/diff.js`)
 output.write('var lineDiffExample="');
 
 // git diff
-const giff = spawn('git', ['diff'].concat(program.args).concat(options));
+const giff = spawn('git', ['diff']
+               .concat(options)
+               .concat(['--'])
+               .concat(program.args));
 giff.stdout.on('data', function (data) {
   // encode to JSON to get escaping
   const encoded = JSON.stringify(data.toString());


### PR DESCRIPTION
```bash
$ cat foo
I am Mr. foo

$ cat bar
I am Mrs. bar

$ giff foo bar
stderr: Not a git repository
To compare two paths outside a working tree:
usage: git diff [--no-index] <path> <path>

/path_to_node_modules/node-giff/index.html
```

So the `giff foo bar` runs the command `git diff foo bar --patience` instead, which results in error.

Refer the `git help diff` output `git diff [<options>] [--] [<path>...]` syntax.

After change the order, the command runs `git diff --patience -- foo bar` instead, so this working.